### PR TITLE
First cut at supporting "redirect" behind an ssl offloader (proxy)

### DIFF
--- a/activeweb/src/main/java/org/javalite/activeweb/RedirectResponse.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/RedirectResponse.java
@@ -30,7 +30,7 @@ class RedirectResponse extends ControllerResponse {
     }
 
     protected RedirectResponse(String path) {
-        if(path == null) throw new IllegalArgumentException("url can't be null");
+        if(path == null) throw new IllegalArgumentException("path can't be null");
         this.path = path;
     }
 

--- a/activeweb/src/test/java/org/javalite/activeweb/HttpSupportSpec.java
+++ b/activeweb/src/test/java/org/javalite/activeweb/HttpSupportSpec.java
@@ -132,6 +132,10 @@ public class HttpSupportSpec extends RequestSpec{
     @Test
     public void shouldRedirectToDifferentAction() throws IOException, ServletException {
 
+        //TODO the name of this method is "different action" but the assertion statement says "different_controller"
+        //so i'm not sure what this spec is actually asserting! So I can't confidently modify it for this change
+        //Help please?
+
         request.setServletPath("/http_support/will_redirect");
         request.setMethod("GET");
         dispatcher.doFilter(request, response, filterChain);
@@ -153,6 +157,16 @@ public class HttpSupportSpec extends RequestSpec{
         request.setMethod("GET");
         dispatcher.doFilter(request, response, filterChain);
         a(response.getRedirectedUrl()).shouldBeEqual("/test_context/hello/abc_action/123?name=john");
+    }
+
+    @Test
+    public void shouldRedirectToControllerForwarded() throws IOException, ServletException {
+
+        request.setServletPath("/http_support/will_redirect_to_controller");
+        request.addHeader("X-FORWARDED-FOR", "x.x.x.x");
+        request.setMethod("GET");
+        dispatcher.doFilter(request, response, filterChain);
+        a(response.getRedirectedUrl()).shouldBeEqual("http://localhost/test_context/hello/abc_action/123?name=john");
     }
 
     @Test


### PR DESCRIPTION
Take a look at this. One path works, but i've put comments in about another path that I think also needs to be changed, but I'm not exactly sure how. 

Also the methods like getRequestProtocol are wierd in that the format of what they return is completely different for normal ("HTTP/1.1") versus when forwarded ("https"). So they're hard to work with. Is anyone using them?

And of course there's the fact I can't test this very well on heroku, because heroku pulls down the maven deps directly to the server. And I don't have my own snapshot repo setup to push my build to. :-(  
