### PR TITLE
Code quality fix - "entrySet()" should be iterated when both the key and value are needed.

### DIFF
--- a/activeweb-testing/src/main/java/org/javalite/activeweb/RequestBuilder.java
+++ b/activeweb-testing/src/main/java/org/javalite/activeweb/RequestBuilder.java
@@ -16,10 +16,11 @@ limitations under the License.
 package org.javalite.activeweb;
 
 import com.google.inject.Injector;
+
 import org.springframework.mock.web.*;
 
-
 import java.util.*;
+import java.util.Map.Entry;
 
 import static org.javalite.activeweb.ControllerFactory.createControllerInstance;
 import static org.javalite.activeweb.ControllerFactory.getControllerClassName;
@@ -404,9 +405,9 @@ public class RequestBuilder {
         }
     }
 
-    private void addHeaders(MockHttpServletRequest request) {        
-        for(String header: headers.keySet()){
-            request.addHeader(header, headers.get(header));
+    private void addHeaders(MockHttpServletRequest request) {
+        for(Entry<String, String> header: headers.entrySet()){
+            request.addHeader(header.getKey(), header.getValue());
         }
     }
 
@@ -420,16 +421,16 @@ public class RequestBuilder {
     }
 
     private void addParameterValues(MockHttpServletRequest httpServletRequest) {
-        for (String key : values.keySet()) {
-            Object value = values.get(key);
+        for (Entry<String, Object> attribute : values.entrySet()) {
+            Object value = attribute.getValue();
             if(value instanceof List){
                 List<String> strings = new ArrayList<String>(((List)value).size());
                 for (Object v: ((List)value)) {
                     strings.add(v.toString());
                 }
-                httpServletRequest.addParameter(key, strings.toArray(new String[]{}));
+                httpServletRequest.addParameter(attribute.getKey(), strings.toArray(new String[]{}));
             }else{
-                httpServletRequest.addParameter(key, value.toString());
+                httpServletRequest.addParameter(attribute.getKey(), value.toString());
             }
         }
     }

--- a/activeweb/src/main/java/org/javalite/activeweb/Configuration.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/Configuration.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Properties;
 
 import static org.javalite.common.Util.blank;
@@ -62,8 +63,8 @@ public class Configuration {
                 overrides.load(in2);
             }
 
-            for (Object name : overrides.keySet()) {
-                props.put(name, overrides.get(name));
+            for (Entry<Object, Object> override : overrides.entrySet()) {
+                props.put(override.getKey(), override.getValue());
             }
             checkInitProperties();
             initTemplateManager();            

--- a/activeweb/src/main/java/org/javalite/activeweb/ControllerRegistry.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/ControllerRegistry.java
@@ -20,6 +20,7 @@ import com.google.inject.Injector;
 
 import javax.servlet.FilterConfig;
 import java.util.*;
+import java.util.Map.Entry;
 
 /**
  * Registration facility for {@link ControllerMetaData}.
@@ -96,8 +97,8 @@ class ControllerRegistry {
                         }
                     }
                     //inject specific controller filters:
-                    for (String key : metaDataMap.keySet()) {
-                        metaDataMap.get(key).injectFilters(injector);
+                    for (Entry<String, ControllerMetaData> metadata : metaDataMap.entrySet()) {
+                    	metadata.getValue().injectFilters(injector);
                     }
                 }
                 filtersInjected = true;

--- a/activeweb/src/main/java/org/javalite/activeweb/RequestUtils.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/RequestUtils.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.Map.Entry;
 
 import static java.util.Arrays.asList;
 import static org.javalite.common.Collections.list;
@@ -364,8 +365,8 @@ public class RequestUtils {
 
         Map<String, String> userSegments = Context.getRequestContext().getUserSegments();
 
-        for(String name:userSegments.keySet()){
-            params.put(name, new String[]{userSegments.get(name)});
+        for(Entry<String, String> userSegment:userSegments.entrySet()){
+            params.put(userSegment.getKey(), new String[]{userSegment.getValue()});
         }
 
         return params;

--- a/activeweb/src/main/java/org/javalite/activeweb/controller_filters/HeadersLogFilter.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/controller_filters/HeadersLogFilter.java
@@ -17,6 +17,7 @@ limitations under the License.
 package org.javalite.activeweb.controller_filters;
 
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * Use this filter to log HTTP request (and response) headers to a log system.
@@ -61,8 +62,8 @@ public class HeadersLogFilter extends AbstractLoggingFilter {
     private String format(Map<String, String> headers){
         StringBuilder sb = new StringBuilder("{");
         int i = 0;
-        for (String header : headers.keySet()) {
-            sb.append("\"").append(header).append("\" : \"").append(headers.get(header)).append("\"");
+        for (Entry<String, String> header : headers.entrySet()) {
+            sb.append("\"").append(header.getKey()).append("\" : \"").append(header.getValue()).append("\"");
             if(i < (headers.size() - 1)){
                 sb.append(", ");
             }

--- a/activeweb/src/main/java/org/javalite/activeweb/freemarker/FreeMarkerTemplateManager.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/freemarker/FreeMarkerTemplateManager.java
@@ -32,6 +32,7 @@ import java.io.*;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import static org.javalite.common.Util.blank;
 
@@ -105,8 +106,8 @@ public class FreeMarkerTemplateManager extends TemplateManager {
                 values.put("page_content", pageWriter.toString());
                 Map<String, List<String>>  assignedValues = ContentTL.getAllContent();
 
-                for(String name: assignedValues.keySet()){
-                    values.put(name, Util.join(assignedValues.get(name), " "));
+                for(Entry<String, List<String>> assignedValue: assignedValues.entrySet()){
+                    values.put(assignedValue.getKey(), Util.join(assignedValue.getValue(), " "));
                 }
 
                 Template layoutTemplate = config.getTemplate(layout + ".ftl");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864

Please let me know if you have any questions.

Faisal Hameed