### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/activeweb-testing/src/main/java/org/javalite/activeweb/DBSpecHelper.java
+++ b/activeweb-testing/src/main/java/org/javalite/activeweb/DBSpecHelper.java
@@ -30,6 +30,8 @@ import java.util.List;
 public class DBSpecHelper {
 
     private static Logger LOGGER = LoggerFactory.getLogger(DBSpecHelper.class.getSimpleName());
+    
+    private DBSpecHelper() {}
 
     public static void initDBConfig() {
 

--- a/activeweb/src/main/java/org/javalite/activeweb/Context.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/Context.java
@@ -39,6 +39,7 @@ class Context {
     private static ThreadLocal<Route> route = new ThreadLocal<Route>();
     private static ThreadLocal<Map<String, Object>> values =new ThreadLocal<Map<String, Object>>();
 
+    private Context() {}
 
     public static Map<String, Object> getValues() {
         return values.get();

--- a/activeweb/src/main/java/org/javalite/activeweb/ControllerFactory.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/ControllerFactory.java
@@ -22,6 +22,7 @@ import org.javalite.common.Inflector;
  */
 public class ControllerFactory {
 
+	private ControllerFactory() {}
 
     protected static AppController createControllerInstance(String controllerClassName) throws ClassLoadException {
         return DynamicClassFactory.createInstance(controllerClassName, AppController.class);

--- a/activeweb/src/main/java/org/javalite/activeweb/ControllerPackageLocator.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/ControllerPackageLocator.java
@@ -38,6 +38,7 @@ class ControllerPackageLocator {
 
     private static Logger LOGGER = LoggerFactory.getLogger(ControllerPackageLocator.class.getSimpleName());
 
+    private ControllerPackageLocator() {}
 
     public static List<String> locateControllerPackages(FilterConfig config) {
         String controllerPath = System.getProperty("file.separator") + Configuration.getRootPackage() + System.getProperty("file.separator") + "controllers";

--- a/activeweb/src/main/java/org/javalite/activeweb/KeyWords.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/KeyWords.java
@@ -23,7 +23,10 @@ import java.util.List;
  * @author Igor Polevoy
  */
 class KeyWords {
-    public static List<String> ACTIVEWEB_KEYWORDS = Arrays.asList("controller", "action", "request", "session");    
+    public static List<String> ACTIVEWEB_KEYWORDS = Arrays.asList("controller", "action", "request", "session");
+    
+    private KeyWords() {}
+    
     static void check(String name){
         if(ACTIVEWEB_KEYWORDS.contains(name))
             throw new IllegalArgumentException("'" + name  + "' is a reserved word");

--- a/activeweb/src/main/java/org/javalite/activeweb/Messages.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/Messages.java
@@ -15,6 +15,8 @@ import java.util.ResourceBundle;
 public class Messages {
 
     private static final String BUNDLE = "activeweb_messages";
+    
+    private Messages() {}
 
     /**
      * Looks for a localized property/message in <code>activeweb_messages</code> bundle.

--- a/activeweb/src/main/java/org/javalite/activeweb/ParamCopy.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/ParamCopy.java
@@ -32,6 +32,7 @@ import static org.javalite.common.Collections.map;
 class ParamCopy {
     private static final Logger LOGGER = LoggerFactory.getLogger(ParamCopy.class.getSimpleName());
 
+    private ParamCopy() {}
 
     static void copyInto(Map assigns){
         insertActiveWebParamsInto(assigns);

--- a/activeweb/src/main/java/org/javalite/activeweb/RequestUtils.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/RequestUtils.java
@@ -18,6 +18,8 @@ import static org.javalite.common.Collections.list;
 public class RequestUtils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RequestUtils.class.getSimpleName());
+    
+    private RequestUtils() {}
 
     /**
      * Returns value of routing user segment, or route wild card value, or request parameter.

--- a/activeweb/src/main/java/org/javalite/activeweb/SessionHelper.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/SessionHelper.java
@@ -25,6 +25,9 @@ import java.util.Map;
  * @author Igor Polevoy
  */
 class SessionHelper {
+	
+	private SessionHelper() {}
+	
     /**
      * Returns all session attributes in a map.
      *

--- a/activeweb/src/main/java/org/javalite/activeweb/async/Host.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/async/Host.java
@@ -7,6 +7,8 @@ import java.net.UnknownHostException;
  * @author Igor Polevoy on 3/4/15.
  */
 public class Host {
+	
+	private Host() {}
 
     public static String get() {
         String res = "127.0.0.1";

--- a/activeweb/src/main/java/org/javalite/activeweb/freemarker/ContentTL.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/freemarker/ContentTL.java
@@ -26,6 +26,8 @@ import java.util.Map;
 public class ContentTL {
     private static ThreadLocal<Map<String, List<String>>> contentTL = new ThreadLocal<Map<String, List<String>>>();
 
+    private ContentTL() {}
+    
     static void reset(){
         contentTL.set(new HashMap<String, List<String>>());
     }

--- a/activeweb/src/main/java/org/javalite/activeweb/freemarker/FreeMarkerTL.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/freemarker/FreeMarkerTL.java
@@ -25,6 +25,8 @@ class FreeMarkerTL {
 
     private static ThreadLocal<Environment> environmentThreadLocal = new ThreadLocal<Environment>();
     
+    private FreeMarkerTL() {}
+    
     public static void setEnvironment(Environment environment){
         environmentThreadLocal.set(environment);
     }

--- a/activeweb/src/main/java/org/javalite/activeweb/freemarker/Util.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/freemarker/Util.java
@@ -23,6 +23,8 @@ import java.util.Map;
  */
 public class Util {
 
+	private Util() {}
+	
     /**
      * Will throw {@link IllegalArgumentException} if a key in the map is missing.
      * If a map does nto have all the passed in keys in it, this method will throw exception. 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed