### PR TITLE
Code quality fix - "@Override" annotation should be used on any method overriding.

### DIFF
--- a/activeweb-testing/src/main/java/org/javalite/activeweb/IntegrationSpec.java
+++ b/activeweb-testing/src/main/java/org/javalite/activeweb/IntegrationSpec.java
@@ -30,6 +30,7 @@ public class IntegrationSpec extends RequestSpecHelper {
         return new RequestBuilder(controllerName, session(), true);
     }
 
+    @Override
     protected void setTemplateLocation(String templateLocation){
         Configuration.getTemplateManager().setTemplateLocation(templateLocation);
     }

--- a/activeweb-testing/src/main/java/org/javalite/activeweb/MockMultipartHttpServletRequestImpl.java
+++ b/activeweb-testing/src/main/java/org/javalite/activeweb/MockMultipartHttpServletRequestImpl.java
@@ -50,34 +50,42 @@ public class MockMultipartHttpServletRequestImpl extends MockHttpServletRequest 
     // Below are Servlet 3 methods
     //Note that the @Override annotations are removed for backwards compatibility
 
+    @Override
     public Collection<Part> getParts() throws IOException, ServletException {
         return null;
     }
 
+    @Override
     public Part getPart(String s) throws IOException, ServletException {
         return null;
     }
 
+    @Override
     public AsyncContext startAsync() throws IllegalStateException {
         return null;
     }
 
+    @Override
     public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) throws IllegalStateException {
         return null;
     }
 
+    @Override
     public boolean isAsyncStarted() {
         return false;
     }
 
+    @Override
     public boolean isAsyncSupported() {
         return false;
     }
 
+    @Override
     public AsyncContext getAsyncContext() {
         return null;
     }
 
+    @Override
     public DispatcherType getDispatcherType() {
         return null;
     }

--- a/activeweb-testing/src/main/java/org/javalite/activeweb/ViewSpec.java
+++ b/activeweb-testing/src/main/java/org/javalite/activeweb/ViewSpec.java
@@ -55,6 +55,7 @@ public abstract class ViewSpec extends SpecHelper {
      * @param templateLocation location of your templates relative to the directory
      * where test is executed, usually a root of your Maven module
      */
+    @Override
     public void setTemplateLocation(String templateLocation){
         manager.setTemplateLocation(templateLocation);
     }
@@ -64,6 +65,7 @@ public abstract class ViewSpec extends SpecHelper {
      *
      * @param injector injector to source dependencies form.
      */
+    @Override
     protected void setInjector(Injector injector){
         Context.getControllerRegistry().setInjector(injector);
     }
@@ -74,6 +76,7 @@ public abstract class ViewSpec extends SpecHelper {
      * @param name name of tag as used in a template.
      * @param tag tag instance
      */
+    @Override
     protected void registerTag(String name, FreeMarkerTag tag) {
         manager.registerTag(name, tag);
         Injector injector = Context.getControllerRegistry().getInjector();

--- a/activeweb/src/main/java/org/javalite/activeweb/AppController.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/AppController.java
@@ -38,6 +38,7 @@ public abstract class AppController extends HttpSupport {
      * @param name name of a value.
      * @param value value.
      */
+    @Override
     protected void assign(String name, Object value) {
         KeyWords.check(name);
         Context.getValues().put(name, value);
@@ -49,6 +50,7 @@ public abstract class AppController extends HttpSupport {
      * @param name name of object to be passed to view
      * @param value object to be passed to view
      */
+    @Override
     protected void view(String name, Object value) {
         assign(name, value);
     }
@@ -96,6 +98,7 @@ public abstract class AppController extends HttpSupport {
         return Context.getHttpRequest().getServletPath();
     }
 
+    @Override
     protected String queryString() {
         return Context.getHttpRequest().getQueryString();
     }

--- a/activeweb/src/main/java/org/javalite/activeweb/Bootstrap.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/Bootstrap.java
@@ -44,6 +44,7 @@ public abstract class Bootstrap extends AppConfig{
      *
      * @param context app context instance
      */
+    @Override
     public abstract void init(AppContext context);
 
     /**

--- a/activeweb/src/main/java/org/javalite/activeweb/DynamicClassLoader.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/DynamicClassLoader.java
@@ -39,6 +39,7 @@ class DynamicClassLoader extends ClassLoader {
         this.baseDir = baseDir;
     }
 
+    @Override
     public Class<?> loadClass(String name) throws ClassNotFoundException {
 
         try{

--- a/activeweb/src/main/java/org/javalite/activeweb/controller_filters/AbstractLoggingFilter.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/controller_filters/AbstractLoggingFilter.java
@@ -52,6 +52,7 @@ public abstract class AbstractLoggingFilter extends HttpSupportFilter{
         this.level = level;
     }
 
+    @Override
     public final void before() {
         log(getMessage() + ", session: " + session().id());
     }

--- a/activeweb/src/main/java/org/javalite/activeweb/controller_filters/HeadersLogFilter.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/controller_filters/HeadersLogFilter.java
@@ -54,6 +54,7 @@ public class HeadersLogFilter extends AbstractLoggingFilter {
         super();    
     }
 
+    @Override
     protected String getMessage() {
         return "Request headers: " + format(headers());
     }

--- a/activeweb/src/main/java/org/javalite/activeweb/controller_filters/RequestPropertiesLogFilter.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/controller_filters/RequestPropertiesLogFilter.java
@@ -47,6 +47,7 @@ public class RequestPropertiesLogFilter extends AbstractLoggingFilter{
         super();    
     }
 
+    @Override
     protected String getMessage() {
         Map m = map("request_url", url(),
                 "context_path", context(),

--- a/activeweb/src/main/java/org/javalite/activeweb/freemarker/FreeMarkerTemplateManager.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/freemarker/FreeMarkerTemplateManager.java
@@ -70,10 +70,12 @@ public class FreeMarkerTemplateManager extends TemplateManager {
         }
     }
 
+    @Override
     public void merge(Map values, String template, Writer writer) {
         merge(values, template, defaultLayout, null, writer);
     }
 
+    @Override
     public void merge(Map input, String template, String layout, String format, Writer writer) {
 
         try {
@@ -133,6 +135,7 @@ public class FreeMarkerTemplateManager extends TemplateManager {
 
     }
     
+    @Override
     public void setServletContext(ServletContext ctx) {
         if(location == null)
             config.setServletContextForTemplateLoading(ctx, "WEB-INF/views/");
@@ -154,6 +157,7 @@ public class FreeMarkerTemplateManager extends TemplateManager {
 
 
 
+    @Override
     public void setTemplateLocation(String templateLocation) {
         location = templateLocation;
 

--- a/activeweb/src/main/java/org/javalite/activeweb/freemarker/TagFactory.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/freemarker/TagFactory.java
@@ -47,6 +47,7 @@ public class TagFactory {
 
     }
 
+    @Override
     public String toString() {
         StringWriter sw = new StringWriter();
         write(sw);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1161 - "@Override" annotation should be used on any method overriding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1161

Please let me know if you have any questions.

Faisal Hameed