### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order.

### DIFF
--- a/activeweb-gwt/src/main/java/org/javalite/activeweb/RPCControllerUtils.java
+++ b/activeweb-gwt/src/main/java/org/javalite/activeweb/RPCControllerUtils.java
@@ -34,8 +34,6 @@ final class RPCControllerUtils {
     
     private static final Logger LOGGER = LoggerFactory.getLogger(RPCControllerUtils.class.getSimpleName());
 
-    private RPCControllerUtils() {
-    }
     /**
      * Package protected for use in tests.
      */
@@ -56,6 +54,9 @@ final class RPCControllerUtils {
      * take place.
      */
     private static final int UNCOMPRESSED_BYTE_SIZE_LIMIT = 256;
+    
+    private RPCControllerUtils() {
+    }
 
     /**
      * Returns <code>true</code> if the {@link HttpServletRequest} accepts Gzip

--- a/activeweb/src/main/java/org/javalite/activeweb/HttpSupport.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/HttpSupport.java
@@ -43,6 +43,7 @@ import static org.javalite.common.Collections.map;
 public class HttpSupport {
     private Logger logger = LoggerFactory.getLogger(getClass().getSimpleName());
     private List<FormItem> formItems;
+    private static Pattern hashPattern = Pattern.compile("\\[.*\\]");
 
     protected void logInfo(String info){
         logger.info(info);
@@ -930,8 +931,6 @@ public class HttpSupport {
         }
         return hash;
     }
-
-    private static Pattern hashPattern = Pattern.compile("\\[.*\\]");
 
     /**
      * Parses name from hash syntax.

--- a/activeweb/src/main/java/org/javalite/activeweb/RequestContext.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/RequestContext.java
@@ -17,7 +17,8 @@ public class RequestContext {
      * They are available as regular parameters using param("name") inside controllers and filter.
      */
     private Map<String, String> userSegments = new HashMap<>();
-
+    
+    private String wildCardName, wildCardValue;
 
     protected Object get(String name){
         return values.get(name);
@@ -30,9 +31,6 @@ public class RequestContext {
     protected void set(String name, Object value){
         values.put(name, value);
     }
-
-
-    private String wildCardName, wildCardValue;
 
     public String getWildCardName() {
         return wildCardName;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Faisal Hameed