### PR TITLE
Code quality fix - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE".

### DIFF
--- a/activeweb/src/main/java/org/javalite/activeweb/RequestDispatcher.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/RequestDispatcher.java
@@ -205,18 +205,12 @@ public class RequestDispatcher implements Filter {
                 return;
             }
 
-            if (route != null) {
-                Context.setRoute(route);
-                if (Configuration.logRequestParams()) {
-                    logger.info("================ New request: " + new Date() + " ================");
-                }
-                runner.run(route, true);
-            } else {
-                //TODO: theoretically this will never happen, because if the route was not excluded, the router.recognize() would throw some kind
-                // of exception, leading to the a system error page.
-                logger.warn("No matching route for servlet path: " + request.getServletPath() + ", passing down to container.");
-                chain.doFilter(req, resp);//let it fall through
+            Context.setRoute(route);
+            if (Configuration.logRequestParams()) {
+                logger.info("================ New request: " + new Date() + " ================");
             }
+            runner.run(route, true);
+            
         } catch (CompilationException e) {
             renderSystemError(e);
         } catch (ClassLoadException e) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE".
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2583

Please let me know if you have any questions.

Faisal Hameed
