### PR TITLE
Multiple code quality fix-1

### DIFF
--- a/activeweb-testing/src/main/java/org/javalite/activeweb/RequestBuilder.java
+++ b/activeweb-testing/src/main/java/org/javalite/activeweb/RequestBuilder.java
@@ -336,7 +336,7 @@ public class RequestBuilder {
         checkParamAndMultipart();
 
         //TODO: refactor this method, getting out of control        
-        if(contentType != null && contentType.equals(MULTIPART) && formItems.size() > 0){
+        if(contentType != null && contentType.equals(MULTIPART) && !formItems.isEmpty()){
             request = new MockMultipartHttpServletRequestImpl();
             for (FormItem item : formItems) {
                 ((AWMockMultipartHttpServletRequest) request).addFormItem(item);

--- a/activeweb/src/main/java/org/javalite/activeweb/RequestDispatcher.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/RequestDispatcher.java
@@ -234,7 +234,7 @@ public class RequestDispatcher implements Filter {
         }finally {
            Context.clear();
             List<String> connectionsRemaining = DB.getCurrrentConnectionNames();
-            if(connectionsRemaining.size() != 0){
+            if(!connectionsRemaining.isEmpty()){
                 logger.warn("CONNECTION LEAK DETECTED ... and AVERTED!!! You left connections opened:"
                         + connectionsRemaining + ". ActiveWeb is closing all active connections for you...");
                 DB.closeAllConnections();

--- a/activeweb/src/main/java/org/javalite/activeweb/RouteBuilder.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/RouteBuilder.java
@@ -237,7 +237,7 @@ public class RouteBuilder {
             String[] tailArr = Arrays.copyOfRange(requestUriSegments, segments.size() - 1, requestUriSegments.length);
             wildCardValue = Util.join(tailArr, "/");
             match = true;
-        }else if(segments.size() == 0 && requestUri.equals("/")){
+        }else if(segments.isEmpty() && requestUri.equals("/")){
             //this is matching root path: "/"
             actionName = "index";
             match = true;
@@ -272,7 +272,7 @@ public class RouteBuilder {
     }
 
     private boolean methodMatches(HttpMethod httpMethod) {
-        return methods.size() == 0 && httpMethod.equals(HttpMethod.GET) || methods.contains(httpMethod);
+        return methods.isEmpty() && httpMethod.equals(HttpMethod.GET) || methods.contains(httpMethod);
     }
 
     private AppController reloadController() throws ClassLoadException {

--- a/activeweb/src/main/java/org/javalite/activeweb/Router.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/Router.java
@@ -384,7 +384,7 @@ public class Router {
                 resultIndex = i;
             }
         }
-        return candidates.size() > 0 ? candidates.get(resultIndex) : null;
+        return !candidates.isEmpty() ? candidates.get(resultIndex) : null;
     }
 
     //todo: write a regexp one day

--- a/javalite-async/src/main/java/org/javalite/async/Async.java
+++ b/javalite-async/src/main/java/org/javalite/async/Async.java
@@ -175,8 +175,8 @@ public class Async {
     private void configurePaging() {
         AddressSettings addressSettings = new AddressSettings();
         addressSettings.setAddressFullMessagePolicy(AddressFullMessagePolicy.PAGE);
-        addressSettings.setMaxSizeBytes(30 * 1024 * 1024);
-        addressSettings.setPageSizeBytes(10 * 1024 * 1024);
+        addressSettings.setMaxSizeBytes(30 * 1024 * 1024L);
+        addressSettings.setPageSizeBytes(10 * 1024 * 1024L);
         addressSettings.setPageCacheMaxSize(20);
         config.getAddressesSettings().put("jms.queue.*", addressSettings);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:S2184 - Math operands should be cast before assignment.
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S2184

Please let me know if you have any questions.

Faisal Hameed