### PR TITLE
Adding reference to underlying response object for low-level operations.

### DIFF
--- a/activeweb/src/main/java/org/javalite/activeweb/HttpSupport.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/HttpSupport.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.*;
 import java.net.URL;
 import java.util.*;
@@ -641,6 +642,15 @@ public class HttpSupport {
      */
     protected HttpServletRequest getHttpServletRequest(){
         return Context.getHttpRequest();
+    }
+    
+    /**
+     * Direct access to current <code>HttpServletResponse</code> for low level operations.
+     *
+     * @return instance of current <code>HttpServletResponse</code>.
+     */
+    protected HttpServletResponse getHttpServletResponse(){
+        return Context.getHttpResponse();
     }
 
     /**


### PR DESCRIPTION
As done in #310 , but for the Response object. This way we can ease the migration from jsp-based systems, and get the api more ergonomic.